### PR TITLE
Added double quotes to string values when using arguments as a table.

### DIFF
--- a/sh.lua
+++ b/sh.lua
@@ -3,7 +3,7 @@ local M = {}
 -- converts key and it's argument to "-k" or "-k=v" or just ""
 local function arg(k, a)
 	if not a then return k end
-	if type(a) == 'string' and #a > 0 then return k..'='..a end
+	if type(a) == 'string' and #a > 0 then return k..'="'..a..'"' end
 	if type(a) == 'number' then return k..'='..tostring(a) end
 	if type(a) == 'boolean' and a == true then return k end
 	error('invalid argument type', type(a), a)


### PR DESCRIPTION
Hello,

I forked your luash repo to change a bit the function arg(k, a).

When using arguments as a table with space inside values, only the first word was interpreted.
Calling yad =>yad( { title='New title', text='A text with spaces' } ) will cause that only 'New' and 'A' are displayed by yad.

Now with my change yad displays the strings the right way.

Could you please merge this commit if you think it won't break anything else.

Thanks
Alex.
