### PR TITLE
Don't set the hook to map undefined variables by default.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Every command that can be called via os.execute can be used a global function.
 All the arguments passed into the function become command arguments.
 
 ``` lua
-require('sh')
+require('sh').install()
 
 local wd = tostring(pwd()) -- calls `pwd` and returns its output as a string
 
@@ -45,7 +45,7 @@ one I/O loop at a time). So the inner-most command is executed, its output is
 read, the the outer command is execute with the output redirected etc.
 
 ``` lua
-require('sh')
+require('sh').install()
 
 local words = 'foo\nbar\nfoo\nbaz\n'
 local u = uniq(sort({__input = words})) -- like $(echo ... | sort | uniq)
@@ -97,7 +97,7 @@ not work in Lua 5.1 and current LuaJIT.
 Key-value arguments can be also specified as argument table pairs:
 
 ```lua
-require('sh')
+require('sh').install()
 
 -- $ somecommand --format=long --interactive -u=0
 somecommand({format="long", interactive=true, u=0})

--- a/sh.lua
+++ b/sh.lua
@@ -89,11 +89,6 @@ if mt == nil then
   setmetatable(_G, mt)
 end
 
--- set hook for undefined variables
-mt.__index = function(t, cmd)
-	return command(cmd)
-end
-
 -- export command() function and configurable temporary "input" file
 M.command = command
 M.tmpfile = '/tmp/shluainput'
@@ -104,5 +99,17 @@ setmetatable(M, {
 		return command(cmd, ...)
 	end
 })
+
+-- Let's luash to deal with undefined variables, those will be commands
+M.install = function()
+  -- set hook for undefined variables
+  mt.__index = function(t, cmd)
+    return command(cmd)
+  end
+  -- Remove install from M now that the feature has been activated
+  M.install = nil
+
+  return M
+end
 
 return M

--- a/tests/test.lua
+++ b/tests/test.lua
@@ -16,7 +16,7 @@ require('gambiarra')(function(e, test, msg)
 	end
 end)
 
-local sh = require('sh')
+local sh = require('sh').install()
 
 test('Check command output', function()
 	ok(tostring(seq(1, 5)) == '1\n2\n3\n4\n5', 'seq 1 5')


### PR DESCRIPTION
While this is a nice feature when using lua as a pure shell script
language, when using `luash` as a module to run shell commands embedded in
another program it's undesirable not to have undefined variables.

That feature can be enabled at any time calling the `install` function
provided by the module or at `require` time as:

```
local sh = require('sh').install()
```