### PR TITLE
Don't open temp file if __input is absent

### DIFF
--- a/sh.lua
+++ b/sh.lua
@@ -33,6 +33,9 @@ local function flatten(t)
 				table.insert(result.args, arg(key, v))
 			end
 		end
+		if result.input == '' then
+			result.input = nil
+		end
 	end
 
 	f(t)
@@ -62,8 +65,9 @@ local function command(cmd, ...)
 		local p = io.popen(s, 'r')
 		local output = p:read('*a')
 		local _, exit, status = p:close()
-		os.remove(M.tmpfile)
-
+		if args.input then
+			os.remove(M.tmpfile)
+		end
 		local t = {
 			__input = output,
 			__exitcode = exit == 'exit' and status or 127,


### PR DESCRIPTION
This fixes a logic bug: due to the truthiness of the empty string,
the temp file is always created, and the shell always called with
a file redirect.

While this is unlikely to change the result of a program, it
could, and the implication of checking for args.input is that this
was unintended behavior.
 On branch fix-input-logic
	modified:   sh.lua